### PR TITLE
Split overloads in Grpc.ChannelConfiguration to clarify intent

### DIFF
--- a/src/Grpc.ChannelConfiguration/GrpcServiceMethodConfigurationExtensions.cs
+++ b/src/Grpc.ChannelConfiguration/GrpcServiceMethodConfigurationExtensions.cs
@@ -63,8 +63,8 @@ public static class GrpcServiceMethodConfigurationExtensions
         return (retryPolicy, hedgingPolicy) switch
         {
             (null, null) => builder,
-            (var policy, null) => ConfigureServiceMethod(builder, methodName, policy),
-            (null, var policy) => ConfigureServiceMethod(builder, methodName, policy),
+            (var policy, null) => SetServiceMethodRetryPolicy(builder, methodName, policy),
+            (null, var policy) => SetServiceMethodHedgingPolicy(builder, methodName, policy),
             (_, _) => throw new ArgumentException("A retry policy can't be combined with a hedging policy."),
         };
     }
@@ -79,7 +79,7 @@ public static class GrpcServiceMethodConfigurationExtensions
     /// </param>
     /// <param name="retryPolicy">The <see cref="RetryPolicy" /> to attach to all service method matching the pattern specified in <paramref name="methodName"/>.</param>
     /// <returns>The configured <see cref="IHttpClientBuilder" />.</returns>
-    public static IHttpClientBuilder ConfigureServiceMethod(this IHttpClientBuilder builder, MethodName methodName, RetryPolicy retryPolicy)
+    public static IHttpClientBuilder SetServiceMethodRetryPolicy(this IHttpClientBuilder builder, MethodName methodName, RetryPolicy retryPolicy)
     {
         _ = builder ?? throw new ArgumentNullException(nameof(builder));
 
@@ -109,7 +109,7 @@ public static class GrpcServiceMethodConfigurationExtensions
     /// </param>
     /// <param name="hedgingPolicy">The <see cref="HedgingPolicy" /> to attach to all service method matching the pattern specified in <paramref name="methodName"/>.</param>
     /// <returns>The configured <see cref="IHttpClientBuilder" />.</returns>
-    public static IHttpClientBuilder ConfigureServiceMethod(this IHttpClientBuilder builder, MethodName methodName, HedgingPolicy hedgingPolicy)
+    public static IHttpClientBuilder SetServiceMethodHedgingPolicy(this IHttpClientBuilder builder, MethodName methodName, HedgingPolicy hedgingPolicy)
     {
         _ = builder ?? throw new ArgumentNullException(nameof(builder));
 
@@ -165,7 +165,7 @@ public static class GrpcServiceMethodConfigurationExtensions
     /// </param>
     /// <param name="retryPolicy">The <see cref="RetryPolicy" /> to attach to all service method matching the pattern specified in <paramref name="methodName"/>.</param>
     /// <returns>The configured <see cref="IHttpClientBuilder" />.</returns>
-    public static IHttpClientBuilder ConfigureServiceMethod(this IHttpClientBuilder builder, string methodName, RetryPolicy retryPolicy)
+    public static IHttpClientBuilder SetServiceMethodRetryPolicy(this IHttpClientBuilder builder, string methodName, RetryPolicy retryPolicy)
     {
         _ = builder ?? throw new ArgumentNullException(nameof(builder));
 
@@ -173,7 +173,7 @@ public static class GrpcServiceMethodConfigurationExtensions
 
         _ = retryPolicy ?? throw new ArgumentNullException(nameof(retryPolicy));
 
-        return ConfigureServiceMethod(builder, ParseKey(methodName), retryPolicy);
+        return SetServiceMethodRetryPolicy(builder, ParseKey(methodName), retryPolicy);
     }
 
     /// <summary>
@@ -189,7 +189,7 @@ public static class GrpcServiceMethodConfigurationExtensions
     /// </param>
     /// <param name="hedgingPolicy">The <see cref="HedgingPolicy" /> to attach to all service method matching the pattern specified in <paramref name="methodName"/>.</param>
     /// <returns>The configured <see cref="IHttpClientBuilder" />.</returns>
-    public static IHttpClientBuilder ConfigureServiceMethod(this IHttpClientBuilder builder, string methodName, HedgingPolicy hedgingPolicy)
+    public static IHttpClientBuilder SetServiceMethodHedgingPolicy(this IHttpClientBuilder builder, string methodName, HedgingPolicy hedgingPolicy)
     {
         _ = builder ?? throw new ArgumentNullException(nameof(builder));
 
@@ -197,7 +197,7 @@ public static class GrpcServiceMethodConfigurationExtensions
 
         _ = hedgingPolicy ?? throw new ArgumentNullException(nameof(hedgingPolicy));
 
-        return ConfigureServiceMethod(builder, ParseKey(methodName), hedgingPolicy);
+        return SetServiceMethodHedgingPolicy(builder, ParseKey(methodName), hedgingPolicy);
     }
 
     /// <summary>
@@ -207,7 +207,7 @@ public static class GrpcServiceMethodConfigurationExtensions
     /// <param name="section">The instance of <see cref="IConfigurationSection" /> containing the configuration to attach to all methods.</param>
     /// <returns>The configured <see cref="IHttpClientBuilder" />.</returns>
     /// <exception cref="ArgumentException">Thrown when the method is configured with both a <see cref="RetryPolicy" /> and a <see creft="HedgingPolicy" />.</exception>
-    public static IHttpClientBuilder ConfigureDefaultServiceMethod(this IHttpClientBuilder builder, IConfigurationSection section)
+    public static IHttpClientBuilder ConfigureServiceMethodFallback(this IHttpClientBuilder builder, IConfigurationSection section)
     {
         _ = builder ?? throw new ArgumentNullException(nameof(builder));
 
@@ -220,13 +220,13 @@ public static class GrpcServiceMethodConfigurationExtensions
     /// <param name="builder">The <see cref="IHttpClientBuilder" /> to configure.</param>
     /// <param name="retryPolicy">The <see cref="RetryPolicy" /> to attach to all service methods.</param>
     /// <returns>The configured <see cref="IHttpClientBuilder" />.</returns>
-    public static IHttpClientBuilder ConfigureDefaultServiceMethod(this IHttpClientBuilder builder, RetryPolicy retryPolicy)
+    public static IHttpClientBuilder SetFallbackRetryPolicy(this IHttpClientBuilder builder, RetryPolicy retryPolicy)
     {
         _ = builder ?? throw new ArgumentNullException(nameof(builder));
 
         _ = retryPolicy ?? throw new ArgumentNullException(nameof(retryPolicy));
 
-        return ConfigureServiceMethod(builder, MethodName.Default, retryPolicy);
+        return SetServiceMethodRetryPolicy(builder, MethodName.Default, retryPolicy);
     }
 
     /// <summary>
@@ -235,13 +235,13 @@ public static class GrpcServiceMethodConfigurationExtensions
     /// <param name="builder">The <see cref="IHttpClientBuilder" /> to configure.</param>
     /// <param name="hedgingPolicy">The <see cref="HedgingPolicy" /> to attach to all service methods.</param>
     /// <returns>The configured <see cref="IHttpClientBuilder" />.</returns>
-    public static IHttpClientBuilder ConfigureDefaultServiceMethod(this IHttpClientBuilder builder, HedgingPolicy hedgingPolicy)
+    public static IHttpClientBuilder SetFallbackHedgingPolicy(this IHttpClientBuilder builder, HedgingPolicy hedgingPolicy)
     {
         _ = builder ?? throw new ArgumentNullException(nameof(builder));
 
         _ = hedgingPolicy ?? throw new ArgumentNullException(nameof(hedgingPolicy));
 
-        return ConfigureServiceMethod(builder, MethodName.Default, hedgingPolicy);
+        return SetServiceMethodHedgingPolicy(builder, MethodName.Default, hedgingPolicy);
     }
 
     private static T LoadPolicy<T>(IConfigurationSection section, string sectionName)

--- a/tests/Tests.Grpc.ChannelConfiguration/GrpcServiceMethodConfigurationExtensionsTests.cs
+++ b/tests/Tests.Grpc.ChannelConfiguration/GrpcServiceMethodConfigurationExtensionsTests.cs
@@ -29,13 +29,13 @@ public class GrpcServiceMethodConfigurationExtensionsTests
     {
         [Test]
         [CustomAutoData]
-        public void ConfigureServiceMethods_does_not_accept_nulls(GuardClauseAssertion assertion) => assertion.Verify(typeof(GrpcServiceMethodConfigurationExtensions).GetMethod(nameof(GrpcServiceMethodConfigurationExtensions.ConfigureServiceMethods)));
+        public void Does_not_accept_nulls(GuardClauseAssertion assertion) => assertion.Verify(typeof(GrpcServiceMethodConfigurationExtensions).GetMethod(nameof(GrpcServiceMethodConfigurationExtensions.ConfigureServiceMethods)));
 
         [Test]
         [CustomInlineAutoData(null!, null!)]
         [CustomInlineAutoData(null!)]
         [CustomInlineAutoData]
-        public void ConfigureServiceMethods_does_nothing_if_no_configuration_is_added(string serviceName, string methodName, ConfigurationBuilder configurationBuilder, ServiceCollection services, Uri uri)
+        public void Does_nothing_if_no_configuration_is_added(string serviceName, string methodName, ConfigurationBuilder configurationBuilder, ServiceCollection services, Uri uri)
         {
             var method = CreateMethodNameString(serviceName, methodName);
 
@@ -62,7 +62,7 @@ public class GrpcServiceMethodConfigurationExtensionsTests
         }
 
         [Test, CustomAutoData]
-        public void ConfigureServiceMethods_can_set_fallback_retry_configuration(ConfigurationBuilder configurationBuilder, ServiceCollection services, Uri uri, RetryPolicy retryPolicy, StatusCode statusCode)
+        public void Can_set_fallback_retry_configuration(ConfigurationBuilder configurationBuilder, ServiceCollection services, Uri uri, RetryPolicy retryPolicy, StatusCode statusCode)
         {
             retryPolicy.RetryableStatusCodes.Add(statusCode);
 
@@ -126,7 +126,7 @@ public class GrpcServiceMethodConfigurationExtensionsTests
         }
 
         [Test, CustomAutoData]
-        public void ConfigureServiceMethods_can_set_fallback_hedging_configuration(ConfigurationBuilder configurationBuilder, ServiceCollection services, Uri uri, HedgingPolicy hedgingPolicy, StatusCode statusCode)
+        public void Can_set_fallback_hedging_configuration(ConfigurationBuilder configurationBuilder, ServiceCollection services, Uri uri, HedgingPolicy hedgingPolicy, StatusCode statusCode)
         {
             hedgingPolicy.NonFatalStatusCodes.Add(statusCode);
 
@@ -187,7 +187,7 @@ public class GrpcServiceMethodConfigurationExtensionsTests
         }
 
         [Test, CustomAutoData]
-        public void ConfigureServiceMethods_throws_if_fallback_configuration_has_both_retry_policy_and_hedging_policy(ConfigurationBuilder configurationBuilder, ServiceCollection services, Uri uri, RetryPolicy retryPolicy, HedgingPolicy hedgingPolicy, StatusCode statusCode)
+        public void Throws_if_fallback_configuration_has_both_retry_policy_and_hedging_policy(ConfigurationBuilder configurationBuilder, ServiceCollection services, Uri uri, RetryPolicy retryPolicy, HedgingPolicy hedgingPolicy, StatusCode statusCode)
         {
             retryPolicy.RetryableStatusCodes.Add(statusCode);
 
@@ -222,7 +222,7 @@ public class GrpcServiceMethodConfigurationExtensionsTests
         }
 
         [Test, CustomAutoData]
-        public void ConfigureServiceMethods_can_set_set_retry_policy_for_service(ConfigurationBuilder configurationBuilder, ServiceCollection services, Uri uri, RetryPolicy retryPolicy, StatusCode statusCode, string serviceName)
+        public void Can_set_set_retry_policy_for_service(ConfigurationBuilder configurationBuilder, ServiceCollection services, Uri uri, RetryPolicy retryPolicy, StatusCode statusCode, string serviceName)
         {
             retryPolicy.RetryableStatusCodes.Add(statusCode);
 
@@ -286,7 +286,7 @@ public class GrpcServiceMethodConfigurationExtensionsTests
         }
 
         [Test, CustomAutoData]
-        public void ConfigureServiceMethods_can_set_set_hedging_policy_for_service(ConfigurationBuilder configurationBuilder, ServiceCollection services, Uri uri, HedgingPolicy hedgingPolicy, StatusCode statusCode, string serviceName)
+        public void Can_set_set_hedging_policy_for_service(ConfigurationBuilder configurationBuilder, ServiceCollection services, Uri uri, HedgingPolicy hedgingPolicy, StatusCode statusCode, string serviceName)
         {
             hedgingPolicy.NonFatalStatusCodes.Add(statusCode);
 
@@ -347,7 +347,7 @@ public class GrpcServiceMethodConfigurationExtensionsTests
         }
 
         [Test, CustomAutoData]
-        public void ConfigureServiceMethods_throws_if_service_configuration_has_both_retry_policy_and_hedging_policy(ConfigurationBuilder configurationBuilder, ServiceCollection services, Uri uri, RetryPolicy retryPolicy, HedgingPolicy hedgingPolicy, StatusCode statusCode, string serviceName)
+        public void Throws_if_service_configuration_has_both_retry_policy_and_hedging_policy(ConfigurationBuilder configurationBuilder, ServiceCollection services, Uri uri, RetryPolicy retryPolicy, HedgingPolicy hedgingPolicy, StatusCode statusCode, string serviceName)
         {
             retryPolicy.RetryableStatusCodes.Add(statusCode);
 
@@ -382,7 +382,7 @@ public class GrpcServiceMethodConfigurationExtensionsTests
         }
 
         [Test, CustomAutoData]
-        public void ConfigureServiceMethods_can_set_retry_policy_for_method(ConfigurationBuilder configurationBuilder, ServiceCollection services, Uri uri, RetryPolicy retryPolicy, StatusCode statusCode, string serviceName, string methodName)
+        public void Can_set_retry_policy_for_method(ConfigurationBuilder configurationBuilder, ServiceCollection services, Uri uri, RetryPolicy retryPolicy, StatusCode statusCode, string serviceName, string methodName)
         {
             retryPolicy.RetryableStatusCodes.Add(statusCode);
 
@@ -446,7 +446,7 @@ public class GrpcServiceMethodConfigurationExtensionsTests
         }
 
         [Test, CustomAutoData]
-        public void ConfigureServiceMethods_can_set_hedging_policy_for_method(ConfigurationBuilder configurationBuilder, ServiceCollection services, Uri uri, HedgingPolicy hedgingPolicy, StatusCode statusCode, string serviceName, string methodName)
+        public void Can_set_hedging_policy_for_method(ConfigurationBuilder configurationBuilder, ServiceCollection services, Uri uri, HedgingPolicy hedgingPolicy, StatusCode statusCode, string serviceName, string methodName)
         {
             hedgingPolicy.NonFatalStatusCodes.Add(statusCode);
 
@@ -508,7 +508,7 @@ public class GrpcServiceMethodConfigurationExtensionsTests
 
 
         [Test, CustomAutoData]
-        public void ConfigureServiceMethods_throws_if_service_configuration_has_both_retry_policy_and_hedging_policy(ConfigurationBuilder configurationBuilder, ServiceCollection services, Uri uri, RetryPolicy retryPolicy, HedgingPolicy hedgingPolicy, StatusCode statusCode, string serviceName, string methodName)
+        public void Throws_if_service_configuration_has_both_retry_policy_and_hedging_policy(ConfigurationBuilder configurationBuilder, ServiceCollection services, Uri uri, RetryPolicy retryPolicy, HedgingPolicy hedgingPolicy, StatusCode statusCode, string serviceName, string methodName)
         {
             retryPolicy.RetryableStatusCodes.Add(statusCode);
 
@@ -548,13 +548,13 @@ public class GrpcServiceMethodConfigurationExtensionsTests
     {
         [Test]
         [CustomAutoData]
-        public void ConfigureServiceMethod_do_not_accept_nulls(GuardClauseAssertion assertion) => assertion.Verify(typeof(GrpcServiceMethodConfigurationExtensions).GetMethods().Where(i => i.Name == nameof(GrpcServiceMethodConfigurationExtensions.ConfigureServiceMethod)));
+        public void Does_not_accept_nulls(GuardClauseAssertion assertion) => assertion.Verify(typeof(GrpcServiceMethodConfigurationExtensions).GetMethods().Where(i => i.Name == nameof(GrpcServiceMethodConfigurationExtensions.ConfigureServiceMethod)));
 
         [Test]
         [CustomInlineAutoData(null!, null!)]
         [CustomInlineAutoData(null!)]
         [CustomInlineAutoData]
-        public void ConfigureServiceMethod_can_configure_method_retry_policy_from_configuration(string methodName, string serviceName, ConfigurationBuilder configurationBuilder, ServiceCollection services, Uri uri, RetryPolicy retryPolicy, StatusCode statusCode)
+        public void Can_configure_method_retry_policy_from_configuration(string methodName, string serviceName, ConfigurationBuilder configurationBuilder, ServiceCollection services, Uri uri, RetryPolicy retryPolicy, StatusCode statusCode)
         {
             var method = new MethodName { Service = serviceName, Method = methodName };
 
@@ -622,7 +622,7 @@ public class GrpcServiceMethodConfigurationExtensionsTests
         [CustomInlineAutoData(null!, null!)]
         [CustomInlineAutoData(null!)]
         [CustomInlineAutoData]
-        public void ConfigureServiceMethod_can_configure_method_hedging_policy_from_configuration(string methodName, string serviceName, ConfigurationBuilder configurationBuilder, ServiceCollection services, Uri uri, HedgingPolicy hedgingPolicy, StatusCode statusCode)
+        public void Can_configure_method_hedging_policy_from_configuration(string methodName, string serviceName, ConfigurationBuilder configurationBuilder, ServiceCollection services, Uri uri, HedgingPolicy hedgingPolicy, StatusCode statusCode)
         {
             var method = new MethodName { Service = serviceName, Method = methodName };
 
@@ -687,7 +687,7 @@ public class GrpcServiceMethodConfigurationExtensionsTests
         [CustomInlineAutoData(null!, null!)]
         [CustomInlineAutoData(null!)]
         [CustomInlineAutoData]
-        public void ConfigureServiceMethod_throws_if_service_configuration_has_both_retry_policy_and_hedging_policy(string methodName, string serviceName, ConfigurationBuilder configurationBuilder, ServiceCollection services, Uri uri, RetryPolicy retryPolicy, HedgingPolicy hedgingPolicy, StatusCode statusCode)
+        public void Throws_if_service_configuration_has_both_retry_policy_and_hedging_policy(string methodName, string serviceName, ConfigurationBuilder configurationBuilder, ServiceCollection services, Uri uri, RetryPolicy retryPolicy, HedgingPolicy hedgingPolicy, StatusCode statusCode)
         {
             var method = new MethodName { Service = serviceName, Method = methodName };
 
@@ -718,108 +718,6 @@ public class GrpcServiceMethodConfigurationExtensionsTests
             var builder = services.AddGrpcClient<TestGrpcClient>(o => o.Address = uri);
 
             Assert.That(() => builder.ConfigureServiceMethod(method, configuration.GetSection("GRPC")), Throws.ArgumentException);
-        }
-
-        [Test]
-        [CustomInlineAutoData(null!, null!)]
-        [CustomInlineAutoData(null!)]
-        [CustomInlineAutoData]
-        public void ConfigureServiceMethod_can_configure_method_retry_policy_from_policy(string methodName, string serviceName, ServiceCollection services, Uri uri, RetryPolicy retryPolicy, StatusCode statusCode)
-        {
-            var method = new MethodName { Service = serviceName, Method = methodName };
-
-            retryPolicy.RetryableStatusCodes.Add(statusCode);
-
-            var builder = services.AddGrpcClient<TestGrpcClient>(o => o.Address = uri);
-
-            builder.ConfigureServiceMethod(method, retryPolicy);
-
-            var options = services.BuildServiceProvider()
-                                .GetRequiredService<IOptionsSnapshot<GrpcClientFactoryOptions>>()
-                                .Get(builder.Name);
-
-            Assume.That(options.ChannelOptionsActions, Has.Exactly(1).InstanceOf<Action<GrpcChannelOptions>>());
-
-            var configurationDelegate = options.ChannelOptionsActions[0];
-
-            var channelOptions = new GrpcChannelOptions();
-
-            configurationDelegate(channelOptions);
-
-            Assert.Multiple(() =>
-            {
-                Assert.That(channelOptions.ServiceConfig, Is.Not.Null);
-
-                Assert.That(channelOptions.ServiceConfig!.MethodConfigs, Has.Exactly(1).InstanceOf<MethodConfig>());
-
-                Assert.That(channelOptions.ServiceConfig!.MethodConfigs[0].Names, Has.Exactly(1).InstanceOf<MethodName>());
-
-                Assert.That(channelOptions.ServiceConfig!.MethodConfigs[0].Names[0].Service, Is.EqualTo(serviceName));
-
-                Assert.That(channelOptions.ServiceConfig!.MethodConfigs[0].Names[0].Method, Is.EqualTo(methodName));
-
-                Assert.That(channelOptions.ServiceConfig!.MethodConfigs[0].HedgingPolicy, Is.Null);
-
-                Assert.That(channelOptions.ServiceConfig!.MethodConfigs[0].RetryPolicy, Is.Not.Null);
-
-                Assert.That(channelOptions.ServiceConfig!.MethodConfigs[0].RetryPolicy!.BackoffMultiplier, Is.EqualTo(retryPolicy.BackoffMultiplier));
-
-                Assert.That(channelOptions.ServiceConfig!.MethodConfigs[0].RetryPolicy!.InitialBackoff, Is.EqualTo(retryPolicy.InitialBackoff));
-
-                Assert.That(channelOptions.ServiceConfig!.MethodConfigs[0].RetryPolicy!.MaxAttempts, Is.EqualTo(retryPolicy.MaxAttempts));
-
-                Assert.That(channelOptions.ServiceConfig!.MethodConfigs[0].RetryPolicy!.RetryableStatusCodes, Is.EquivalentTo(retryPolicy.RetryableStatusCodes));
-            });
-        }
-
-        [Test]
-        [CustomInlineAutoData(null!, null!)]
-        [CustomInlineAutoData(null!)]
-        [CustomInlineAutoData]
-        public void ConfigureServiceMethod_can_configure_method_hedging_policy_from_policy(string methodName, string serviceName, ServiceCollection services, Uri uri, HedgingPolicy hedgingPolicy, StatusCode statusCode)
-        {
-            var method = new MethodName { Service = serviceName, Method = methodName };
-
-            hedgingPolicy.NonFatalStatusCodes.Add(statusCode);
-
-            var builder = services.AddGrpcClient<TestGrpcClient>(o => o.Address = uri);
-
-            builder.ConfigureServiceMethod(method, hedgingPolicy);
-
-            var options = services.BuildServiceProvider()
-                                .GetRequiredService<IOptionsSnapshot<GrpcClientFactoryOptions>>()
-                                .Get(builder.Name);
-
-            Assume.That(options.ChannelOptionsActions, Has.Exactly(1).InstanceOf<Action<GrpcChannelOptions>>());
-
-            var configurationDelegate = options.ChannelOptionsActions[0];
-
-            var channelOptions = new GrpcChannelOptions();
-
-            configurationDelegate(channelOptions);
-
-            Assert.Multiple(() =>
-            {
-                Assert.That(channelOptions.ServiceConfig, Is.Not.Null);
-
-                Assert.That(channelOptions.ServiceConfig!.MethodConfigs, Has.Exactly(1).InstanceOf<MethodConfig>());
-
-                Assert.That(channelOptions.ServiceConfig!.MethodConfigs[0].Names, Has.Exactly(1).InstanceOf<MethodName>());
-
-                Assert.That(channelOptions.ServiceConfig!.MethodConfigs[0].Names[0].Service, Is.EqualTo(serviceName));
-
-                Assert.That(channelOptions.ServiceConfig!.MethodConfigs[0].Names[0].Method, Is.EqualTo(methodName));
-
-                Assert.That(channelOptions.ServiceConfig!.MethodConfigs[0].RetryPolicy, Is.Null);
-
-                Assert.That(channelOptions.ServiceConfig!.MethodConfigs[0].HedgingPolicy, Is.Not.Null);
-
-                Assert.That(channelOptions.ServiceConfig!.MethodConfigs[0].HedgingPolicy!.HedgingDelay, Is.EqualTo(hedgingPolicy.HedgingDelay));
-
-                Assert.That(channelOptions.ServiceConfig!.MethodConfigs[0].HedgingPolicy!.MaxAttempts, Is.EqualTo(hedgingPolicy.MaxAttempts));
-
-                Assert.That(channelOptions.ServiceConfig!.MethodConfigs[0].HedgingPolicy!.NonFatalStatusCodes, Is.EquivalentTo(hedgingPolicy.NonFatalStatusCodes));
-            });
         }
 
         [Test]
@@ -1023,108 +921,6 @@ public class GrpcServiceMethodConfigurationExtensionsTests
         [CustomInlineAutoData(null!, null!)]
         [CustomInlineAutoData(null!)]
         [CustomInlineAutoData]
-        public void ConfigureServiceMethod_can_configure_string_method_retry_policy_from_policy(string methodName, string serviceName, ServiceCollection services, Uri uri, RetryPolicy retryPolicy, StatusCode statusCode)
-        {
-            var method = CreateMethodNameString(serviceName, methodName);
-
-            retryPolicy.RetryableStatusCodes.Add(statusCode);
-
-            var builder = services.AddGrpcClient<TestGrpcClient>(o => o.Address = uri);
-
-            builder.ConfigureServiceMethod(method, retryPolicy);
-
-            var options = services.BuildServiceProvider()
-                                .GetRequiredService<IOptionsSnapshot<GrpcClientFactoryOptions>>()
-                                .Get(builder.Name);
-
-            Assume.That(options.ChannelOptionsActions, Has.Exactly(1).InstanceOf<Action<GrpcChannelOptions>>());
-
-            var configurationDelegate = options.ChannelOptionsActions[0];
-
-            var channelOptions = new GrpcChannelOptions();
-
-            configurationDelegate(channelOptions);
-
-            Assert.Multiple(() =>
-            {
-                Assert.That(channelOptions.ServiceConfig, Is.Not.Null);
-
-                Assert.That(channelOptions.ServiceConfig!.MethodConfigs, Has.Exactly(1).InstanceOf<MethodConfig>());
-
-                Assert.That(channelOptions.ServiceConfig!.MethodConfigs[0].Names, Has.Exactly(1).InstanceOf<MethodName>());
-
-                Assert.That(channelOptions.ServiceConfig!.MethodConfigs[0].Names[0].Service, Is.EqualTo(serviceName));
-
-                Assert.That(channelOptions.ServiceConfig!.MethodConfigs[0].Names[0].Method, Is.EqualTo(methodName));
-
-                Assert.That(channelOptions.ServiceConfig!.MethodConfigs[0].HedgingPolicy, Is.Null);
-
-                Assert.That(channelOptions.ServiceConfig!.MethodConfigs[0].RetryPolicy, Is.Not.Null);
-
-                Assert.That(channelOptions.ServiceConfig!.MethodConfigs[0].RetryPolicy!.BackoffMultiplier, Is.EqualTo(retryPolicy.BackoffMultiplier));
-
-                Assert.That(channelOptions.ServiceConfig!.MethodConfigs[0].RetryPolicy!.InitialBackoff, Is.EqualTo(retryPolicy.InitialBackoff));
-
-                Assert.That(channelOptions.ServiceConfig!.MethodConfigs[0].RetryPolicy!.MaxAttempts, Is.EqualTo(retryPolicy.MaxAttempts));
-
-                Assert.That(channelOptions.ServiceConfig!.MethodConfigs[0].RetryPolicy!.RetryableStatusCodes, Is.EquivalentTo(retryPolicy.RetryableStatusCodes));
-            });
-        }
-
-        [Test]
-        [CustomInlineAutoData(null!, null!)]
-        [CustomInlineAutoData(null!)]
-        [CustomInlineAutoData]
-        public void ConfigureServiceMethod_can_configure_string_method_hedging_policy_from_policy(string methodName, string serviceName, ServiceCollection services, Uri uri, HedgingPolicy hedgingPolicy, StatusCode statusCode)
-        {
-            var method = CreateMethodNameString(serviceName, methodName);
-
-            hedgingPolicy.NonFatalStatusCodes.Add(statusCode);
-
-            var builder = services.AddGrpcClient<TestGrpcClient>(o => o.Address = uri);
-
-            builder.ConfigureServiceMethod(method, hedgingPolicy);
-
-            var options = services.BuildServiceProvider()
-                                .GetRequiredService<IOptionsSnapshot<GrpcClientFactoryOptions>>()
-                                .Get(builder.Name);
-
-            Assume.That(options.ChannelOptionsActions, Has.Exactly(1).InstanceOf<Action<GrpcChannelOptions>>());
-
-            var configurationDelegate = options.ChannelOptionsActions[0];
-
-            var channelOptions = new GrpcChannelOptions();
-
-            configurationDelegate(channelOptions);
-
-            Assert.Multiple(() =>
-            {
-                Assert.That(channelOptions.ServiceConfig, Is.Not.Null);
-
-                Assert.That(channelOptions.ServiceConfig!.MethodConfigs, Has.Exactly(1).InstanceOf<MethodConfig>());
-
-                Assert.That(channelOptions.ServiceConfig!.MethodConfigs[0].Names, Has.Exactly(1).InstanceOf<MethodName>());
-
-                Assert.That(channelOptions.ServiceConfig!.MethodConfigs[0].Names[0].Service, Is.EqualTo(serviceName));
-
-                Assert.That(channelOptions.ServiceConfig!.MethodConfigs[0].Names[0].Method, Is.EqualTo(methodName));
-
-                Assert.That(channelOptions.ServiceConfig!.MethodConfigs[0].RetryPolicy, Is.Null);
-
-                Assert.That(channelOptions.ServiceConfig!.MethodConfigs[0].HedgingPolicy, Is.Not.Null);
-
-                Assert.That(channelOptions.ServiceConfig!.MethodConfigs[0].HedgingPolicy!.HedgingDelay, Is.EqualTo(hedgingPolicy.HedgingDelay));
-
-                Assert.That(channelOptions.ServiceConfig!.MethodConfigs[0].HedgingPolicy!.MaxAttempts, Is.EqualTo(hedgingPolicy.MaxAttempts));
-
-                Assert.That(channelOptions.ServiceConfig!.MethodConfigs[0].HedgingPolicy!.NonFatalStatusCodes, Is.EquivalentTo(hedgingPolicy.NonFatalStatusCodes));
-            });
-        }
-
-        [Test]
-        [CustomInlineAutoData(null!, null!)]
-        [CustomInlineAutoData(null!)]
-        [CustomInlineAutoData]
         public void ConfigureServiceMethod_does_nothing_if_no_configuration_is_added_for_string_method(string serviceName, string methodName, ConfigurationBuilder configurationBuilder, ServiceCollection services, Uri uri)
         {
             var method = CreateMethodNameString(serviceName, methodName);
@@ -1150,15 +946,236 @@ public class GrpcServiceMethodConfigurationExtensionsTests
 
     }
 
-    [TestOf(nameof(GrpcServiceMethodConfigurationExtensions.ConfigureDefaultServiceMethod))]
+    [TestOf(nameof(GrpcServiceMethodConfigurationExtensions.SetServiceMethodRetryPolicy))]
+    public class SetServiceMethodRetryPolicy
+    {
+        [Test]
+        [CustomAutoData]
+        public void Does_not_accept_nulls(GuardClauseAssertion assertion) => assertion.Verify(typeof(GrpcServiceMethodConfigurationExtensions).GetMethods().Where(i => i.Name == nameof(GrpcServiceMethodConfigurationExtensions.SetServiceMethodRetryPolicy)));
+
+        [Test]
+        [CustomInlineAutoData(null!, null!)]
+        [CustomInlineAutoData(null!)]
+        [CustomInlineAutoData]
+        public void Can_configure_method_retry_policy_from_policy(string methodName, string serviceName, ServiceCollection services, Uri uri, RetryPolicy retryPolicy, StatusCode statusCode)
+        {
+            var method = new MethodName { Service = serviceName, Method = methodName };
+
+            retryPolicy.RetryableStatusCodes.Add(statusCode);
+
+            var builder = services.AddGrpcClient<TestGrpcClient>(o => o.Address = uri);
+
+            builder.SetServiceMethodRetryPolicy(method, retryPolicy);
+
+            var options = services.BuildServiceProvider()
+                                .GetRequiredService<IOptionsSnapshot<GrpcClientFactoryOptions>>()
+                                .Get(builder.Name);
+
+            Assume.That(options.ChannelOptionsActions, Has.Exactly(1).InstanceOf<Action<GrpcChannelOptions>>());
+
+            var configurationDelegate = options.ChannelOptionsActions[0];
+
+            var channelOptions = new GrpcChannelOptions();
+
+            configurationDelegate(channelOptions);
+
+            Assert.Multiple(() =>
+            {
+                Assert.That(channelOptions.ServiceConfig, Is.Not.Null);
+
+                Assert.That(channelOptions.ServiceConfig!.MethodConfigs, Has.Exactly(1).InstanceOf<MethodConfig>());
+
+                Assert.That(channelOptions.ServiceConfig!.MethodConfigs[0].Names, Has.Exactly(1).InstanceOf<MethodName>());
+
+                Assert.That(channelOptions.ServiceConfig!.MethodConfigs[0].Names[0].Service, Is.EqualTo(serviceName));
+
+                Assert.That(channelOptions.ServiceConfig!.MethodConfigs[0].Names[0].Method, Is.EqualTo(methodName));
+
+                Assert.That(channelOptions.ServiceConfig!.MethodConfigs[0].HedgingPolicy, Is.Null);
+
+                Assert.That(channelOptions.ServiceConfig!.MethodConfigs[0].RetryPolicy, Is.Not.Null);
+
+                Assert.That(channelOptions.ServiceConfig!.MethodConfigs[0].RetryPolicy!.BackoffMultiplier, Is.EqualTo(retryPolicy.BackoffMultiplier));
+
+                Assert.That(channelOptions.ServiceConfig!.MethodConfigs[0].RetryPolicy!.InitialBackoff, Is.EqualTo(retryPolicy.InitialBackoff));
+
+                Assert.That(channelOptions.ServiceConfig!.MethodConfigs[0].RetryPolicy!.MaxAttempts, Is.EqualTo(retryPolicy.MaxAttempts));
+
+                Assert.That(channelOptions.ServiceConfig!.MethodConfigs[0].RetryPolicy!.RetryableStatusCodes, Is.EquivalentTo(retryPolicy.RetryableStatusCodes));
+            });
+        }
+
+        [Test]
+        [CustomInlineAutoData(null!, null!)]
+        [CustomInlineAutoData(null!)]
+        [CustomInlineAutoData]
+        public void Can_configure_string_method_retry_policy_from_policy(string methodName, string serviceName, ServiceCollection services, Uri uri, RetryPolicy retryPolicy, StatusCode statusCode)
+        {
+            var method = CreateMethodNameString(serviceName, methodName);
+
+            retryPolicy.RetryableStatusCodes.Add(statusCode);
+
+            var builder = services.AddGrpcClient<TestGrpcClient>(o => o.Address = uri);
+
+            builder.SetServiceMethodRetryPolicy(method, retryPolicy);
+
+            var options = services.BuildServiceProvider()
+                                .GetRequiredService<IOptionsSnapshot<GrpcClientFactoryOptions>>()
+                                .Get(builder.Name);
+
+            Assume.That(options.ChannelOptionsActions, Has.Exactly(1).InstanceOf<Action<GrpcChannelOptions>>());
+
+            var configurationDelegate = options.ChannelOptionsActions[0];
+
+            var channelOptions = new GrpcChannelOptions();
+
+            configurationDelegate(channelOptions);
+
+            Assert.Multiple(() =>
+            {
+                Assert.That(channelOptions.ServiceConfig, Is.Not.Null);
+
+                Assert.That(channelOptions.ServiceConfig!.MethodConfigs, Has.Exactly(1).InstanceOf<MethodConfig>());
+
+                Assert.That(channelOptions.ServiceConfig!.MethodConfigs[0].Names, Has.Exactly(1).InstanceOf<MethodName>());
+
+                Assert.That(channelOptions.ServiceConfig!.MethodConfigs[0].Names[0].Service, Is.EqualTo(serviceName));
+
+                Assert.That(channelOptions.ServiceConfig!.MethodConfigs[0].Names[0].Method, Is.EqualTo(methodName));
+
+                Assert.That(channelOptions.ServiceConfig!.MethodConfigs[0].HedgingPolicy, Is.Null);
+
+                Assert.That(channelOptions.ServiceConfig!.MethodConfigs[0].RetryPolicy, Is.Not.Null);
+
+                Assert.That(channelOptions.ServiceConfig!.MethodConfigs[0].RetryPolicy!.BackoffMultiplier, Is.EqualTo(retryPolicy.BackoffMultiplier));
+
+                Assert.That(channelOptions.ServiceConfig!.MethodConfigs[0].RetryPolicy!.InitialBackoff, Is.EqualTo(retryPolicy.InitialBackoff));
+
+                Assert.That(channelOptions.ServiceConfig!.MethodConfigs[0].RetryPolicy!.MaxAttempts, Is.EqualTo(retryPolicy.MaxAttempts));
+
+                Assert.That(channelOptions.ServiceConfig!.MethodConfigs[0].RetryPolicy!.RetryableStatusCodes, Is.EquivalentTo(retryPolicy.RetryableStatusCodes));
+            });
+        }
+
+    }
+
+    [TestOf(nameof(GrpcServiceMethodConfigurationExtensions.SetServiceMethodHedgingPolicy))]
+    public class SetServiceMethodHedgingPolicy
+    {
+        [Test]
+        [CustomAutoData]
+        public void Does_not_accept_nulls(GuardClauseAssertion assertion) => assertion.Verify(typeof(GrpcServiceMethodConfigurationExtensions).GetMethods().Where(i => i.Name == nameof(GrpcServiceMethodConfigurationExtensions.SetServiceMethodHedgingPolicy)));
+
+        [Test]
+        [CustomInlineAutoData(null!, null!)]
+        [CustomInlineAutoData(null!)]
+        [CustomInlineAutoData]
+        public void Can_configure_method_hedging_policy_from_policy(string methodName, string serviceName, ServiceCollection services, Uri uri, HedgingPolicy hedgingPolicy, StatusCode statusCode)
+        {
+            var method = new MethodName { Service = serviceName, Method = methodName };
+
+            hedgingPolicy.NonFatalStatusCodes.Add(statusCode);
+
+            var builder = services.AddGrpcClient<TestGrpcClient>(o => o.Address = uri);
+
+            builder.SetServiceMethodHedgingPolicy(method, hedgingPolicy);
+
+            var options = services.BuildServiceProvider()
+                                .GetRequiredService<IOptionsSnapshot<GrpcClientFactoryOptions>>()
+                                .Get(builder.Name);
+
+            Assume.That(options.ChannelOptionsActions, Has.Exactly(1).InstanceOf<Action<GrpcChannelOptions>>());
+
+            var configurationDelegate = options.ChannelOptionsActions[0];
+
+            var channelOptions = new GrpcChannelOptions();
+
+            configurationDelegate(channelOptions);
+
+            Assert.Multiple(() =>
+            {
+                Assert.That(channelOptions.ServiceConfig, Is.Not.Null);
+
+                Assert.That(channelOptions.ServiceConfig!.MethodConfigs, Has.Exactly(1).InstanceOf<MethodConfig>());
+
+                Assert.That(channelOptions.ServiceConfig!.MethodConfigs[0].Names, Has.Exactly(1).InstanceOf<MethodName>());
+
+                Assert.That(channelOptions.ServiceConfig!.MethodConfigs[0].Names[0].Service, Is.EqualTo(serviceName));
+
+                Assert.That(channelOptions.ServiceConfig!.MethodConfigs[0].Names[0].Method, Is.EqualTo(methodName));
+
+                Assert.That(channelOptions.ServiceConfig!.MethodConfigs[0].RetryPolicy, Is.Null);
+
+                Assert.That(channelOptions.ServiceConfig!.MethodConfigs[0].HedgingPolicy, Is.Not.Null);
+
+                Assert.That(channelOptions.ServiceConfig!.MethodConfigs[0].HedgingPolicy!.HedgingDelay, Is.EqualTo(hedgingPolicy.HedgingDelay));
+
+                Assert.That(channelOptions.ServiceConfig!.MethodConfigs[0].HedgingPolicy!.MaxAttempts, Is.EqualTo(hedgingPolicy.MaxAttempts));
+
+                Assert.That(channelOptions.ServiceConfig!.MethodConfigs[0].HedgingPolicy!.NonFatalStatusCodes, Is.EquivalentTo(hedgingPolicy.NonFatalStatusCodes));
+            });
+        }
+
+        [Test]
+        [CustomInlineAutoData(null!, null!)]
+        [CustomInlineAutoData(null!)]
+        [CustomInlineAutoData]
+        public void Can_configure_string_method_hedging_policy_from_policy(string methodName, string serviceName, ServiceCollection services, Uri uri, HedgingPolicy hedgingPolicy, StatusCode statusCode)
+        {
+            var method = CreateMethodNameString(serviceName, methodName);
+
+            hedgingPolicy.NonFatalStatusCodes.Add(statusCode);
+
+            var builder = services.AddGrpcClient<TestGrpcClient>(o => o.Address = uri);
+
+            builder.SetServiceMethodHedgingPolicy(method, hedgingPolicy);
+
+            var options = services.BuildServiceProvider()
+                                .GetRequiredService<IOptionsSnapshot<GrpcClientFactoryOptions>>()
+                                .Get(builder.Name);
+
+            Assume.That(options.ChannelOptionsActions, Has.Exactly(1).InstanceOf<Action<GrpcChannelOptions>>());
+
+            var configurationDelegate = options.ChannelOptionsActions[0];
+
+            var channelOptions = new GrpcChannelOptions();
+
+            configurationDelegate(channelOptions);
+
+            Assert.Multiple(() =>
+            {
+                Assert.That(channelOptions.ServiceConfig, Is.Not.Null);
+
+                Assert.That(channelOptions.ServiceConfig!.MethodConfigs, Has.Exactly(1).InstanceOf<MethodConfig>());
+
+                Assert.That(channelOptions.ServiceConfig!.MethodConfigs[0].Names, Has.Exactly(1).InstanceOf<MethodName>());
+
+                Assert.That(channelOptions.ServiceConfig!.MethodConfigs[0].Names[0].Service, Is.EqualTo(serviceName));
+
+                Assert.That(channelOptions.ServiceConfig!.MethodConfigs[0].Names[0].Method, Is.EqualTo(methodName));
+
+                Assert.That(channelOptions.ServiceConfig!.MethodConfigs[0].RetryPolicy, Is.Null);
+
+                Assert.That(channelOptions.ServiceConfig!.MethodConfigs[0].HedgingPolicy, Is.Not.Null);
+
+                Assert.That(channelOptions.ServiceConfig!.MethodConfigs[0].HedgingPolicy!.HedgingDelay, Is.EqualTo(hedgingPolicy.HedgingDelay));
+
+                Assert.That(channelOptions.ServiceConfig!.MethodConfigs[0].HedgingPolicy!.MaxAttempts, Is.EqualTo(hedgingPolicy.MaxAttempts));
+
+                Assert.That(channelOptions.ServiceConfig!.MethodConfigs[0].HedgingPolicy!.NonFatalStatusCodes, Is.EquivalentTo(hedgingPolicy.NonFatalStatusCodes));
+            });
+        }
+    }
+
+    [TestOf(nameof(GrpcServiceMethodConfigurationExtensions.ConfigureServiceMethodFallback))]
     public class ConfigureDefaultServiceMethod
     {
         [Test]
         [CustomAutoData]
-        public void ConfigureDefaultServiceMethod_do_not_accept_nulls(GuardClauseAssertion assertion) => assertion.Verify(typeof(GrpcServiceMethodConfigurationExtensions).GetMethods().Where(i => i.Name == nameof(GrpcServiceMethodConfigurationExtensions.ConfigureDefaultServiceMethod)));
+        public void Does_not_accept_nulls(GuardClauseAssertion assertion) => assertion.Verify(typeof(GrpcServiceMethodConfigurationExtensions).GetMethods().Where(i => i.Name == nameof(GrpcServiceMethodConfigurationExtensions.ConfigureServiceMethodFallback)));
     
         [Test, CustomAutoData]
-        public void ConfigureDefaultServiceMethod_can_set_fallback_retry_configuration(ConfigurationBuilder configurationBuilder, ServiceCollection services, Uri uri, RetryPolicy retryPolicy, StatusCode statusCode)
+        public void Can_set_fallback_retry_configuration(ConfigurationBuilder configurationBuilder, ServiceCollection services, Uri uri, RetryPolicy retryPolicy, StatusCode statusCode)
         {
             retryPolicy.RetryableStatusCodes.Add(statusCode);
 
@@ -1178,7 +1195,7 @@ public class GrpcServiceMethodConfigurationExtensionsTests
 
             var configuration = configurationBuilder.AddObject(testConfiguration).Build();
 
-            var builder = services.AddGrpcClient<TestGrpcClient>(o => o.Address = uri).ConfigureDefaultServiceMethod(configuration.GetSection("GRPC"));
+            var builder = services.AddGrpcClient<TestGrpcClient>(o => o.Address = uri).ConfigureServiceMethodFallback(configuration.GetSection("GRPC"));
 
             var provider = services.BuildServiceProvider();
 
@@ -1219,7 +1236,7 @@ public class GrpcServiceMethodConfigurationExtensionsTests
         }
 
         [Test, CustomAutoData]
-        public void ConfigureDefaultServiceMethod_can_set_fallback_hedging_configuration(ConfigurationBuilder configurationBuilder, ServiceCollection services, Uri uri, HedgingPolicy hedgingPolicy, StatusCode statusCode)
+        public void Can_set_fallback_hedging_configuration(ConfigurationBuilder configurationBuilder, ServiceCollection services, Uri uri, HedgingPolicy hedgingPolicy, StatusCode statusCode)
         {
             hedgingPolicy.NonFatalStatusCodes.Add(statusCode);
 
@@ -1238,7 +1255,7 @@ public class GrpcServiceMethodConfigurationExtensionsTests
 
             var configuration = configurationBuilder.AddObject(testConfiguration).Build();
 
-            var builder = services.AddGrpcClient<TestGrpcClient>(o => o.Address = uri).ConfigureDefaultServiceMethod(configuration.GetSection("GRPC"));
+            var builder = services.AddGrpcClient<TestGrpcClient>(o => o.Address = uri).ConfigureServiceMethodFallback(configuration.GetSection("GRPC"));
 
             var provider = services.BuildServiceProvider();
 
@@ -1277,7 +1294,7 @@ public class GrpcServiceMethodConfigurationExtensionsTests
         }
 
         [Test, CustomAutoData]
-        public void ConfigureDefaultServiceMethod_throws_if_fallback_configuration_has_both_retry_policy_and_hedging_policy(ConfigurationBuilder configurationBuilder, ServiceCollection services, Uri uri, RetryPolicy retryPolicy, HedgingPolicy hedgingPolicy, StatusCode statusCode)
+        public void Throws_if_fallback_configuration_has_both_retry_policy_and_hedging_policy(ConfigurationBuilder configurationBuilder, ServiceCollection services, Uri uri, RetryPolicy retryPolicy, HedgingPolicy hedgingPolicy, StatusCode statusCode)
         {
             retryPolicy.RetryableStatusCodes.Add(statusCode);
 
@@ -1305,17 +1322,48 @@ public class GrpcServiceMethodConfigurationExtensionsTests
 
             var builder = services.AddGrpcClient<TestGrpcClient>(o => o.Address = uri);
 
-            Assert.That(() => builder.ConfigureDefaultServiceMethod(configuration.GetSection("GRPC")), Throws.ArgumentException);
+            Assert.That(() => builder.ConfigureServiceMethodFallback(configuration.GetSection("GRPC")), Throws.ArgumentException);
         }    
 
         [Test, CustomAutoData]
-        public void ConfigureDefaultServiceMethod_can_set_fallback_retry_policy(ServiceCollection services, Uri uri, RetryPolicy retryPolicy, StatusCode statusCode)
+        public void Does_nothing_if_no_configuration_is_added_for_string_method(ConfigurationBuilder configurationBuilder, ServiceCollection services, Uri uri)
+        {
+            var testConfiguration = new
+            {
+                GRPC = new Dictionary<string, object>
+                {
+                    ["Foo"] = "Bar"
+                }
+            };
+
+            var configuration = configurationBuilder.AddObject(testConfiguration).Build();
+
+            var builder = services.AddGrpcClient<TestGrpcClient>(o => o.Address = uri)
+                                    .ConfigureServiceMethodFallback(configuration.GetSection("GRPC"));
+
+            var provider = services.BuildServiceProvider();
+
+            var options = provider.GetRequiredService<IOptionsSnapshot<GrpcClientFactoryOptions>>().Get(builder.Name);
+
+            Assert.That(options.ChannelOptionsActions, Has.No.InstanceOf<Action<GrpcChannelOptions>>());
+        }
+    }
+
+    [TestOf(nameof(GrpcServiceMethodConfigurationExtensions.SetFallbackRetryPolicy))]
+    public class SetFallbackRetryPolicy
+    {
+        [Test]
+        [CustomAutoData]
+        public void Does_not_accept_nulls(GuardClauseAssertion assertion) => assertion.Verify(typeof(GrpcServiceMethodConfigurationExtensions).GetMethods().Where(i => i.Name == nameof(GrpcServiceMethodConfigurationExtensions.SetFallbackRetryPolicy)));
+
+        [Test, CustomAutoData]
+        public void Can_set_fallback_retry_policy(ServiceCollection services, Uri uri, RetryPolicy retryPolicy, StatusCode statusCode)
         {
             retryPolicy.RetryableStatusCodes.Add(statusCode);
 
             var builder = services.AddGrpcClient<TestGrpcClient>(o => o.Address = uri);
 
-            builder.ConfigureDefaultServiceMethod(retryPolicy);
+            builder.SetFallbackRetryPolicy(retryPolicy);
 
             var options = services.BuildServiceProvider()
                                 .GetRequiredService<IOptionsSnapshot<GrpcClientFactoryOptions>>()
@@ -1355,14 +1403,23 @@ public class GrpcServiceMethodConfigurationExtensionsTests
             });
         }
 
+    }
+
+    [TestOf(nameof(GrpcServiceMethodConfigurationExtensions.SetFallbackHedgingPolicy))]
+    public class SetFallbackHedgingPolicy
+    {
+        [Test]
+        [CustomAutoData]
+        public void Does_not_accept_nulls(GuardClauseAssertion assertion) => assertion.Verify(typeof(GrpcServiceMethodConfigurationExtensions).GetMethods().Where(i => i.Name == nameof(GrpcServiceMethodConfigurationExtensions.SetFallbackHedgingPolicy)));
+
         [Test, CustomAutoData]
-        public void ConfigureDefaultServiceMethod_can_set_fallback_hedging_policy(ServiceCollection services, Uri uri, HedgingPolicy hedgingPolicy, StatusCode statusCode)
+        public void Can_set_fallback_hedging_policy(ServiceCollection services, Uri uri, HedgingPolicy hedgingPolicy, StatusCode statusCode)
         {
             hedgingPolicy.NonFatalStatusCodes.Add(statusCode);
 
             var builder = services.AddGrpcClient<TestGrpcClient>(o => o.Address = uri);
 
-            builder.ConfigureDefaultServiceMethod(hedgingPolicy);
+            builder.SetFallbackHedgingPolicy(hedgingPolicy);
 
             var options = services.BuildServiceProvider()
                                 .GetRequiredService<IOptionsSnapshot<GrpcClientFactoryOptions>>()
@@ -1400,26 +1457,5 @@ public class GrpcServiceMethodConfigurationExtensionsTests
             });
         }
 
-        [Test, CustomAutoData]
-        public void ConfigureServiceMethod_does_nothing_if_no_configuration_is_added_for_string_method(string serviceName, string methodName, ConfigurationBuilder configurationBuilder, ServiceCollection services, Uri uri)
-        {
-            var testConfiguration = new
-            {
-                GRPC = new Dictionary<string, object>
-                {
-                    ["Foo"] = "Bar"
-                }
-            };
-
-            var configuration = configurationBuilder.AddObject(testConfiguration).Build();
-
-            var builder = services.AddGrpcClient<TestGrpcClient>(o => o.Address = uri).ConfigureDefaultServiceMethod(configuration.GetSection("GRPC"));
-
-            var provider = services.BuildServiceProvider();
-
-            var options = provider.GetRequiredService<IOptionsSnapshot<GrpcClientFactoryOptions>>().Get(builder.Name);
-
-            Assert.That(options.ChannelOptionsActions, Has.No.InstanceOf<Action<GrpcChannelOptions>>());
-        }
     }
 }


### PR DESCRIPTION
This PR break ups some overload groups to clarify intent of each method.