### PR TITLE
add config flag to ignore authenticated status

### DIFF
--- a/src/AnonymousUser/AnonymousUser.csproj
+++ b/src/AnonymousUser/AnonymousUser.csproj
@@ -2,6 +2,7 @@
 
   <PropertyGroup>
     <TargetFramework>netstandard2.1</TargetFramework>
+    <RootNamespace>InsightArchitectures.Extensions.AspNetCore.AnonymousUser</RootNamespace>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/AnonymousUser/AnonymousUserMiddleware.cs
+++ b/src/AnonymousUser/AnonymousUserMiddleware.cs
@@ -56,7 +56,7 @@ namespace InsightArchitectures.Extensions.AspNetCore.AnonymousUser
                 uid = _options.UserIdentifierFactory.Invoke(httpContext);
                 var encodedUid = await cookieEncoder.EncodeAsync(uid);
 
-                var cookieOptions = new CookieOptions {Expires = _options.Expires,};
+                var cookieOptions = new CookieOptions { Expires = _options.Expires };
 
                 httpContext.Response.Cookies.Append(_options.CookieName, encodedUid, cookieOptions);
             }

--- a/src/AnonymousUser/AnonymousUserMiddleware.cs
+++ b/src/AnonymousUser/AnonymousUserMiddleware.cs
@@ -11,8 +11,8 @@ namespace InsightArchitectures.Extensions.AspNetCore.AnonymousUser
     /// </summary>
     public class AnonymousUserMiddleware
     {
-        private RequestDelegate _nextDelegate;
-        private AnonymousUserOptions _options;
+        private readonly RequestDelegate _nextDelegate;
+        private readonly AnonymousUserOptions _options;
 
         /// <summary>
         /// Constructor requires the next delegate and options.
@@ -25,10 +25,14 @@ namespace InsightArchitectures.Extensions.AspNetCore.AnonymousUser
 
         private async Task HandleRequestAsync(HttpContext httpContext)
         {
-            var cookieEncoder = _options.EncoderService ?? throw new ArgumentNullException(nameof(_options.EncoderService), $"{nameof(_options.EncoderService)} is null and should have a valid encoder.");
-            _ = _options.UserIdentifierFactory ?? throw new ArgumentNullException(nameof(_options.UserIdentifierFactory), $"{nameof(_options.UserIdentifierFactory)} is null and should have a valid factory.");
+            var cookieEncoder = _options.EncoderService ?? throw new ArgumentNullException(
+                nameof(_options.EncoderService),
+                $"{nameof(_options.EncoderService)} is null and should have a valid encoder.");
+            _ = _options.UserIdentifierFactory ?? throw new ArgumentNullException(
+                nameof(_options.UserIdentifierFactory),
+                $"{nameof(_options.UserIdentifierFactory)} is null and should have a valid factory.");
 
-            if (httpContext.User.Identity?.IsAuthenticated == true)
+            if (_options.SkipAuthenticated && httpContext.User.Identity?.IsAuthenticated == true)
             {
                 return;
             }
@@ -52,16 +56,22 @@ namespace InsightArchitectures.Extensions.AspNetCore.AnonymousUser
                 uid = _options.UserIdentifierFactory.Invoke(httpContext);
                 var encodedUid = await cookieEncoder.EncodeAsync(uid);
 
-                var cookieOptions = new CookieOptions
-                {
-                    Expires = _options.Expires,
-                };
+                var cookieOptions = new CookieOptions {Expires = _options.Expires,};
 
                 httpContext.Response.Cookies.Append(_options.CookieName, encodedUid, cookieOptions);
             }
 
-            var identity = new ClaimsIdentity(new[] { new Claim(_options.ClaimType, uid) });
-            httpContext.User.AddIdentity(identity);
+            var claim = new Claim(_options.ClaimType, uid);
+
+            if (httpContext.User.Identity is ClaimsIdentity ci)
+            {
+                ci.AddClaim(claim);
+            }
+            else
+            {
+                var identity = new ClaimsIdentity(new[] { claim });
+                httpContext.User.AddIdentity(identity);
+            }
         }
 
         /// <summary>

--- a/src/AnonymousUser/AnonymousUserOptions.cs
+++ b/src/AnonymousUser/AnonymousUserOptions.cs
@@ -20,6 +20,9 @@ namespace InsightArchitectures.Extensions.AspNetCore.AnonymousUser
         /// <summary>Should the cookie only be allowed on https requests.</summary>
         public bool Secure { get; set; }
 
+        /// <summary>Should the anonymous session id be skipped when an user is authenticated.</summary>
+        public bool SkipAuthenticated { get; set; }
+
         /// <summary>Can be overridden to customise the ID generation.</summary>
         public Func<HttpContext, string> UserIdentifierFactory { get; set; } = _ => Guid.NewGuid().ToString();
 


### PR DESCRIPTION
This adds a config option to ignore the current authenticated status and add a claim to the current logged in user